### PR TITLE
Bump halo2 tag

### DIFF
--- a/halo2wrong/Cargo.toml
+++ b/halo2wrong/Cargo.toml
@@ -23,7 +23,7 @@ optional = true
 [dependencies.halo2_kzg]
 package = "halo2_proofs"
 git = "https://github.com/privacy-scaling-explorations/halo2.git"
-tag = "v2022_05_09"
+tag = "v2022_06_03"
 optional = true
 
 [features]


### PR DESCRIPTION
@kilic After this is merged, could you tag this new commit as `v2022_06_03` so that it can be easily referenced from `zkevm-circuits`?