### PR TITLE
fix compile error

### DIFF
--- a/halo2wrong/src/lib.rs
+++ b/halo2wrong/src/lib.rs
@@ -1,6 +1,6 @@
 use halo2::{
     arithmetic::FieldExt,
-    circuit::{AssignedCell, Cell, Region},
+    circuit::{AssignedCell, Cell, Region, Value},
     plonk::{Advice, Column, Error, Fixed, Selector},
 };
 
@@ -25,7 +25,7 @@ impl<'a, 'b, F: FieldExt> RegionCtx<'a, 'b, F> {
         value: F,
     ) -> Result<AssignedCell<F, F>, Error> {
         self.region
-            .assign_fixed(|| annotation, column, *self.offset, || Ok(value))
+            .assign_fixed(|| annotation, column, *self.offset, || Value::known(value))
     }
 
     pub fn assign_advice(
@@ -38,7 +38,7 @@ impl<'a, 'b, F: FieldExt> RegionCtx<'a, 'b, F> {
             || annotation,
             column,
             *self.offset,
-            || value.ok_or(Error::Synthesis),
+            || Value::known(value.unwrap_or_default()),
         )
     }
 

--- a/maingate/src/range.rs
+++ b/maingate/src/range.rs
@@ -25,6 +25,7 @@ use crate::halo2::poly::Rotation;
 use crate::instructions::{CombinationOptionCommon, MainGateInstructions, Term};
 use crate::{AssignedValue, UnassignedValue};
 use halo2wrong::RegionCtx;
+use halo2wrong::halo2::circuit::Value;
 
 const NUMBER_OF_LOOKUP_LIMBS: usize = 4;
 
@@ -271,7 +272,7 @@ impl<F: FieldExt> RangeInstructions<F> for RangeChip<F> {
                         || "limb range table",
                         self.config.dense_limb_range_table,
                         index,
-                        || Ok(value),
+                        || Value::known(value),
                     )?;
                 }
                 Ok(())
@@ -293,7 +294,7 @@ impl<F: FieldExt> RangeInstructions<F> for RangeChip<F> {
                             || "overflow table",
                             overflow_table.column,
                             index,
-                            || Ok(value),
+                            || Value::known(value),
                         )?;
                     }
                     Ok(())


### PR DESCRIPTION
Meet an error when compile the project:

```
   Compiling halo2wrong v0.1.0 (/appliedzkp-pse/halo2wrong/halo2wrong)
error[E0308]: mismatched types
  --> halo2wrong/src/lib.rs:28:67
   |
28 |             .assign_fixed(|| annotation, column, *self.offset, || Ok(value))
   |                                                                   ^^^^^^^^^ expected struct `Value`, found enum `Result`
   |
   = note: expected struct `Value<_>`
                found enum `Result<F, _>`

error[E0308]: mismatched types
  --> halo2wrong/src/lib.rs:41:16
   |
41 |             || value.ok_or(Error::Synthesis),
   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected struct `Value`, found enum `Result`
   |
   = note: expected struct `Value<_>`
                found enum `Result<F, halo2_proofs::plonk::Error>`

For more information about this error, try `rustc --explain E0308`.
error: could not compile `halo2wrong` due to 2 previous errors
warning: build failed, waiting for other jobs to finish...
error: build failed
```

Maybe something wrong in project setting, anyway, I wrote a simple fix for it. 

Signed-off-by: smtmfft <smtm@taiko.xyz>