### PR TITLE
Refactor `RangeInstructions` for decomposition results

### DIFF
--- a/ecc/src/base_field_ecc.rs
+++ b/ecc/src/base_field_ecc.rs
@@ -409,10 +409,16 @@ mod tests {
             let rns = BaseFieldEccChip::<C, NUMBER_OF_LIMBS, BIT_LEN_LIMB>::rns();
 
             let main_gate_config = MainGate::<C::Scalar>::configure(meta);
-            let mut overflow_bit_lengths: Vec<usize> = vec![];
-            overflow_bit_lengths.extend(rns.overflow_lengths());
-            let range_config =
-                RangeChip::<C::Scalar>::configure(meta, &main_gate_config, overflow_bit_lengths);
+            let overflow_bit_lens = rns.overflow_lengths();
+            let composition_bit_lens = vec![BIT_LEN_LIMB / NUMBER_OF_LIMBS];
+
+            let range_config = RangeChip::<C::Scalar>::configure(
+                meta,
+                &main_gate_config,
+                composition_bit_lens,
+                overflow_bit_lens,
+            );
+
             TestCircuitConfig {
                 main_gate_config,
                 range_config,
@@ -420,10 +426,9 @@ mod tests {
         }
 
         fn config_range<N: FieldExt>(&self, layouter: &mut impl Layouter<N>) -> Result<(), Error> {
-            let bit_len_lookup = BIT_LEN_LIMB / NUMBER_OF_LOOKUP_LIMBS;
-            let range_chip = RangeChip::<N>::new(self.range_config.clone(), bit_len_lookup);
-            range_chip.load_limb_range_table(layouter)?;
-            range_chip.load_overflow_range_tables(layouter)?;
+            let range_chip = RangeChip::<N>::new(self.range_config.clone());
+            range_chip.load_composition_tables(layouter)?;
+            range_chip.load_overflow_tables(layouter)?;
 
             Ok(())
         }

--- a/ecc/src/general_ecc.rs
+++ b/ecc/src/general_ecc.rs
@@ -469,11 +469,18 @@ mod tests {
                 GeneralEccChip::<C, N, NUMBER_OF_LIMBS, BIT_LEN_LIMB>::rns();
 
             let main_gate_config = MainGate::<N>::configure(meta);
-            let mut overflow_bit_lengths: Vec<usize> = vec![];
-            overflow_bit_lengths.extend(rns_base.overflow_lengths());
-            overflow_bit_lengths.extend(rns_scalar.overflow_lengths());
-            let range_config =
-                RangeChip::<N>::configure(meta, &main_gate_config, overflow_bit_lengths);
+            let mut overflow_bit_lens: Vec<usize> = vec![];
+            overflow_bit_lens.extend(rns_base.overflow_lengths());
+            overflow_bit_lens.extend(rns_scalar.overflow_lengths());
+            let composition_bit_lens = vec![BIT_LEN_LIMB / NUMBER_OF_LIMBS];
+
+            let range_config = RangeChip::<N>::configure(
+                meta,
+                &main_gate_config,
+                composition_bit_lens,
+                overflow_bit_lens,
+            );
+
             TestCircuitConfig {
                 main_gate_config,
                 range_config,
@@ -481,10 +488,9 @@ mod tests {
         }
 
         fn config_range<N: FieldExt>(&self, layouter: &mut impl Layouter<N>) -> Result<(), Error> {
-            let bit_len_lookup = BIT_LEN_LIMB / NUMBER_OF_LOOKUP_LIMBS;
-            let range_chip = RangeChip::<N>::new(self.range_config.clone(), bit_len_lookup);
-            range_chip.load_limb_range_table(layouter)?;
-            range_chip.load_overflow_range_tables(layouter)?;
+            let range_chip = RangeChip::<N>::new(self.range_config.clone());
+            range_chip.load_composition_tables(layouter)?;
+            range_chip.load_overflow_tables(layouter)?;
 
             Ok(())
         }

--- a/integer/src/chip/assign.rs
+++ b/integer/src/chip/assign.rs
@@ -46,17 +46,24 @@ impl<W: FieldExt, N: FieldExt, const NUMBER_OF_LIMBS: usize, const BIT_LEN_LIMB:
                             // Most significant limb
                             if i == NUMBER_OF_LIMBS - 1 {
                                 AssignedLimb::from(
-                                    range_chip.range_value(
+                                    range_chip.assign(
                                         ctx,
                                         integer.limb(i),
+                                        Self::sublimb_bit_len(),
                                         bit_len_limb_msb,
                                     )?,
                                     max_val_msb.clone(),
                                 )
+
                             // Rest
                             } else {
                                 AssignedLimb::from(
-                                    range_chip.range_value(ctx, integer.limb(i), BIT_LEN_LIMB)?,
+                                    range_chip.assign(
+                                        ctx,
+                                        integer.limb(i),
+                                        Self::sublimb_bit_len(),
+                                        BIT_LEN_LIMB,
+                                    )?,
                                     max_val.clone(),
                                 )
                             },

--- a/integer/src/chip/div.rs
+++ b/integer/src/chip/div.rs
@@ -59,8 +59,8 @@ impl<W: FieldExt, N: FieldExt, const NUMBER_OF_LIMBS: usize, const BIT_LEN_LIMB:
         let quotient = &self.assign_integer(ctx, quotient.into(), Range::MulQuotient)?;
         let residues = witness
             .residues()
-            .into_iter()
-            .map(|v| range_chip.range_value(ctx, v, self.rns.mul_v_bit_len))
+            .iter()
+            .map(|v| range_chip.assign(ctx, *v, Self::sublimb_bit_len(), self.rns.mul_v_bit_len))
             .collect::<Result<Vec<AssignedValue<N>>, Error>>()?;
 
         let mut t: Vec<AssignedValue<N>> = vec![];

--- a/integer/src/chip/mul.rs
+++ b/integer/src/chip/mul.rs
@@ -91,8 +91,8 @@ impl<W: FieldExt, N: FieldExt, const NUMBER_OF_LIMBS: usize, const BIT_LEN_LIMB:
         let quotient = &self.assign_integer(ctx, quotient.into(), Range::MulQuotient)?;
         let residues = witness
             .residues()
-            .into_iter()
-            .map(|v| range_chip.range_value(ctx, v, self.rns.mul_v_bit_len))
+            .iter()
+            .map(|v| range_chip.assign(ctx, *v, Self::sublimb_bit_len(), self.rns.mul_v_bit_len))
             .collect::<Result<Vec<AssignedValue<N>>, Error>>()?;
 
         // Witness layout for `NUMBER_OF_LIMBS = 4`:
@@ -209,8 +209,8 @@ impl<W: FieldExt, N: FieldExt, const NUMBER_OF_LIMBS: usize, const BIT_LEN_LIMB:
         let result = &self.assign_integer(ctx, result.into(), Range::Remainder)?;
         let residues = witness
             .residues()
-            .into_iter()
-            .map(|v| range_chip.range_value(ctx, v, self.rns.mul_v_bit_len))
+            .iter()
+            .map(|v| range_chip.assign(ctx, *v, Self::sublimb_bit_len(), self.rns.mul_v_bit_len))
             .collect::<Result<Vec<AssignedValue<N>>, Error>>()?;
 
         // Assign intermediate values
@@ -278,8 +278,8 @@ impl<W: FieldExt, N: FieldExt, const NUMBER_OF_LIMBS: usize, const BIT_LEN_LIMB:
         let quotient = &self.assign_integer(ctx, quotient.into(), Range::MulQuotient)?;
         let residues = witness
             .residues()
-            .into_iter()
-            .map(|v| range_chip.range_value(ctx, v, self.rns.mul_v_bit_len))
+            .iter()
+            .map(|v| range_chip.assign(ctx, *v, Self::sublimb_bit_len(), self.rns.mul_v_bit_len))
             .collect::<Result<Vec<AssignedValue<N>>, Error>>()?;
 
         let mut t: Vec<AssignedValue<N>> = vec![];

--- a/integer/src/chip/reduce.rs
+++ b/integer/src/chip/reduce.rs
@@ -87,11 +87,11 @@ impl<W: FieldExt, N: FieldExt, const NUMBER_OF_LIMBS: usize, const BIT_LEN_LIMB:
         // Apply ranges
         let range_chip = self.range_chip();
         let result = &self.assign_integer(ctx, result.into(), Range::Remainder)?;
-        let quotient = range_chip.range_value(ctx, quotient, BIT_LEN_LIMB)?;
+        let quotient = range_chip.assign(ctx, quotient, Self::sublimb_bit_len(), BIT_LEN_LIMB)?;
         let residues = witness
             .residues()
-            .into_iter()
-            .map(|v| range_chip.range_value(ctx, v, self.rns.red_v_bit_len))
+            .iter()
+            .map(|v| range_chip.assign(ctx, *v, Self::sublimb_bit_len(), self.rns.red_v_bit_len))
             .collect::<Result<Vec<AssignedValue<N>>, Error>>()?;
 
         // Assign intermediate values

--- a/integer/src/chip/square.rs
+++ b/integer/src/chip/square.rs
@@ -33,8 +33,8 @@ impl<W: FieldExt, N: FieldExt, const NUMBER_OF_LIMBS: usize, const BIT_LEN_LIMB:
         let quotient = &self.assign_integer(ctx, quotient.into(), Range::MulQuotient)?;
         let residues = witness
             .residues()
-            .into_iter()
-            .map(|v| range_chip.range_value(ctx, v, self.rns.mul_v_bit_len))
+            .iter()
+            .map(|v| range_chip.assign(ctx, *v, Self::sublimb_bit_len(), self.rns.mul_v_bit_len))
             .collect::<Result<Vec<AssignedValue<N>>, Error>>()?;
 
         // Follow same witness layout with mul:

--- a/integer/src/rns.rs
+++ b/integer/src/rns.rs
@@ -600,6 +600,7 @@ impl<W: FieldExt, N: FieldExt, const NUMBER_OF_LIMBS: usize, const BIT_LEN_LIMB:
     }
 
     /// Computes the overflow that each component of the [`Rns`] must support.
+    // TODO: consider soundness of only single overflow length
     pub fn overflow_lengths(&self) -> Vec<usize> {
         let max_most_significant_mul_quotient_limb_size =
             self.max_most_significant_mul_quotient_limb.bits() as usize % self.bit_len_lookup;

--- a/maingate/src/main_gate.rs
+++ b/maingate/src/main_gate.rs
@@ -12,13 +12,24 @@ use crate::halo2::arithmetic::FieldExt;
 use crate::halo2::circuit::{Chip, Layouter};
 use crate::halo2::plonk::{Advice, Column, ConstraintSystem, Error, Fixed, Instance};
 use crate::halo2::poly::Rotation;
-use crate::instructions::{ColumnTags, CombinationOptionCommon, MainGateInstructions, Term};
+use crate::instructions::{CombinationOptionCommon, MainGateInstructions, Term};
 use crate::{AssignedCondition, AssignedValue};
 use halo2wrong::halo2::circuit::Value;
 use halo2wrong::RegionCtx;
 use std::marker::PhantomData;
 
 const WIDTH: usize = 5;
+
+/// `ColumnTags` is an helper to find special columns that are frequently used
+/// across gates
+pub trait ColumnTags<Column> {
+    /// Next row accumulator
+    fn next() -> Column;
+    /// First column
+    fn first() -> Column;
+    /// Index that last term should in linear combination
+    fn last_term_index() -> usize;
+}
 
 /// Enumerates columns of the main gate
 #[derive(Debug)]
@@ -40,8 +51,12 @@ impl ColumnTags<MainGateColumn> for MainGateColumn {
         MainGateColumn::A
     }
 
-    fn accumulator() -> Self {
+    fn next() -> Self {
         MainGateColumn::E
+    }
+
+    fn last_term_index() -> usize {
+        Self::first() as usize
     }
 }
 

--- a/maingate/src/range.rs
+++ b/maingate/src/range.rs
@@ -1,21 +1,7 @@
-//! `RangeChip` decomposes given `AssignedValue` upto 5 limbs and checks if
-//! limbs are in the range and ensures composition of limbs are equal to the
-//! input. `RangeChip` only applies bit range check rather than more general
-//! purpose check.
-//! `B` column is special to check overflows and smaller ranges and `E` column
-//! is allocated for the input. For example if our application requires to check
-//! if a value is in 50 bit range we should configure `base_bit_len` to 16 bits
-//! and for the overflow `B` column also should be able to check 2 bit ranges.
-//! And layout will look like:
-//!
-//! | A   | B   | C   | D   | E   |
-//! | --- | --- | --- | --- | --- |
-//! | a_0 | a_3 | a_1 | a_2 | in  |
-//!
-//! Where `a_3` is the overflow check and other columns are ensuring that limbs
-//! of decomposed value is in 16 bit range.
+use std::collections::HashMap;
+use std::marker::PhantomData;
 
-use super::main_gate::{MainGate, MainGateColumn, MainGateConfig};
+use super::main_gate::{MainGate, MainGateConfig};
 use crate::halo2::arithmetic::FieldExt;
 use crate::halo2::circuit::Chip;
 use crate::halo2::circuit::Layouter;
@@ -23,48 +9,39 @@ use crate::halo2::circuit::Value;
 use crate::halo2::plonk::{ConstraintSystem, Error};
 use crate::halo2::plonk::{Selector, TableColumn};
 use crate::halo2::poly::Rotation;
-use crate::instructions::{CombinationOptionCommon, MainGateInstructions, Term};
+use crate::instructions::{MainGateInstructions, Term};
 use crate::AssignedValue;
 use halo2wrong::utils::decompose;
 use halo2wrong::RegionCtx;
+use num_integer::Integer;
 
-const NUMBER_OF_LOOKUP_LIMBS: usize = 4;
+/// Maximum number of cells in one line enabled with composition selector
+pub const NUMBER_OF_LOOKUP_LIMBS: usize = 4;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
 struct TableConfig {
     selector: Selector,
     column: TableColumn,
-    bit_len: usize,
 }
+
+impl TableConfig {}
 
 /// Range gate configuration
 #[derive(Clone, Debug)]
 pub struct RangeConfig {
     main_gate_config: MainGateConfig,
-    s_dense_limb_range: Selector,
-    dense_limb_range_table: TableColumn,
-    fine_tune_tables: Vec<TableConfig>,
+    composition_tables: HashMap<usize, TableConfig>,
+    overflow_tables: HashMap<usize, TableConfig>,
 }
 
 /// ['RangeChip'] applies binary range constraints
 #[derive(Debug)]
 pub struct RangeChip<F: FieldExt> {
     config: RangeConfig,
-    base_bit_len: usize,
-    left_shifter: Vec<F>,
+    _marker: PhantomData<F>,
 }
 
 impl<F: FieldExt> RangeChip<F> {
-    fn get_table(&self, bit_len: usize) -> Result<&TableConfig, Error> {
-        let table_config = self
-            .config
-            .fine_tune_tables
-            .iter()
-            .find(|&table_config| table_config.bit_len == bit_len)
-            .ok_or(Error::Synthesis)?;
-        Ok(table_config)
-    }
-
     fn main_gate_config(&self) -> MainGateConfig {
         self.config.main_gate_config.clone()
     }
@@ -87,213 +64,125 @@ impl<F: FieldExt> Chip<F> for RangeChip<F> {
 
 /// Generic chip interface for bitwise ranging values
 pub trait RangeInstructions<F: FieldExt>: Chip<F> {
-    /// Ranges new witness with given bit lenght. Expects bit_le
-    fn range_value(
+    /// Assigns new witness
+    fn assign(
         &self,
         ctx: &mut RegionCtx<'_, '_, F>,
-        input: Value<F>,
+        unassigned: Value<F>,
+        limb_bit_len: usize,
         bit_len: usize,
     ) -> Result<AssignedValue<F>, Error>;
 
+    /// Decomposes and assign new witness
+    fn decompose(
+        &self,
+        ctx: &mut RegionCtx<'_, '_, F>,
+        unassigned: Value<F>,
+        limb_bit_len: usize,
+        bit_len: usize,
+    ) -> Result<(AssignedValue<F>, Vec<AssignedValue<F>>), Error>;
+
     /// Appends base limb length table in sythnesis time
-    fn load_limb_range_table(&self, layouter: &mut impl Layouter<F>) -> Result<(), Error>;
+    fn load_composition_tables(&self, layouter: &mut impl Layouter<F>) -> Result<(), Error>;
     /// Appends shorter range tables in sythesis time
-    fn load_overflow_range_tables(&self, layouter: &mut impl Layouter<F>) -> Result<(), Error>;
+    fn load_overflow_tables(&self, layouter: &mut impl Layouter<F>) -> Result<(), Error>;
 }
 
 impl<F: FieldExt> RangeInstructions<F> for RangeChip<F> {
-    fn range_value(
+    fn assign(
         &self,
         ctx: &mut RegionCtx<'_, '_, F>,
-        input: Value<F>,
+        unassigned: Value<F>,
+        limb_bit_len: usize,
         bit_len: usize,
     ) -> Result<AssignedValue<F>, Error> {
+        let (assigned, _) = self.decompose(ctx, unassigned, limb_bit_len, bit_len)?;
+        Ok(assigned)
+    }
+
+    fn decompose(
+        &self,
+        ctx: &mut RegionCtx<'_, '_, F>,
+        unassigned: Value<F>,
+        limb_bit_len: usize,
+        bit_len: usize,
+    ) -> Result<(AssignedValue<F>, Vec<AssignedValue<F>>), Error> {
+        // let number_of_limbs = bit_len % base_bit_len;
+        let (number_of_limbs, overflow_bit_len) = bit_len.div_rem(&limb_bit_len);
+
+        let number_of_limbs = number_of_limbs + if overflow_bit_len > 0 { 1 } else { 0 };
+        let bases = Self::bases(number_of_limbs, limb_bit_len);
+        let decomposed =
+            unassigned.map(|unassigned| decompose(unassigned, number_of_limbs, limb_bit_len));
+
+        let terms: Vec<Term<F>> = bases
+            .into_iter()
+            .enumerate()
+            .map(|(i, base)| {
+                let limb = decomposed.as_ref().map(|limb| limb[i]);
+                Term::Unassigned(limb, base)
+            })
+            .collect();
+
+        let composition_table = self
+            .config
+            .composition_tables
+            .get(&limb_bit_len)
+            .unwrap_or_else(|| {
+                panic!("composition table is not set, bit lenght: {}", limb_bit_len)
+            });
         let main_gate = self.main_gate();
-        let (one, zero) = (F::one(), F::zero());
-        let r = self.left_shifter[0];
-        let rr = self.left_shifter[1];
-        let rrr = self.left_shifter[2];
-        let rrrr = self.left_shifter[3];
-
-        let number_of_dense_limbs = bit_len / self.base_bit_len;
-        let fine_limb_bit_len = bit_len % self.base_bit_len;
-        let number_of_limbs = number_of_dense_limbs + if fine_limb_bit_len == 0 { 0 } else { 1 };
-
-        assert!(number_of_dense_limbs < NUMBER_OF_LOOKUP_LIMBS + 1);
-        assert!(number_of_limbs > 0);
-
-        if number_of_dense_limbs != 0 {
-            // Enable dense decomposion range check.
-            // Notice that fine tune limb will be in the dense limb set.
-            ctx.enable(self.config.s_dense_limb_range)?
-        }
-
-        // Bases for linear combination to the input.
-        let bases = vec![one, r, rr, rrr, rrrr];
-
-        if (number_of_dense_limbs == 1 && fine_limb_bit_len == 0) || number_of_dense_limbs == 0 {
-            // Single row range proof case
-            // Only assign the input to this row
-
-            // Open small table selector if this value is in small table
-            if number_of_dense_limbs == 0 {
-                ctx.enable(self.get_table(fine_limb_bit_len)?.selector)?;
+        main_gate.decompose(ctx, &terms[..], F::zero(), |is_last| {
+            if is_last && overflow_bit_len != 0 {
+                let overflow_table = self
+                    .config
+                    .overflow_tables
+                    .get(&overflow_bit_len)
+                    .unwrap_or_else(|| {
+                        panic!(
+                            "overflow table is not set, bit lenght: {}",
+                            overflow_bit_len
+                        )
+                    });
+                vec![composition_table.selector, overflow_table.selector]
+            } else {
+                vec![composition_table.selector]
             }
-
-            // | A   | B   | C   | D   | E   |
-            // | --- | --- | --- | --- | --- |
-            // | -   | a_0 | -   | -   | -   |
-            main_gate.assign_to_column(ctx, input, MainGateColumn::B)
-        } else {
-            let first_row_with_fine_tune = number_of_dense_limbs < 4 && fine_limb_bit_len != 0;
-            let has_overflow = number_of_dense_limbs == 4 && fine_limb_bit_len > 0;
-
-            // Enable table selector for last limb ie fine tuning limb.
-            if first_row_with_fine_tune {
-                ctx.enable(self.get_table(fine_limb_bit_len)?.selector)?;
-            }
-
-            // Input is decomposed insto smaller limbs
-            let limbs = input.map(|e| decompose(e, number_of_limbs, self.base_bit_len));
-
-            // Witness layouts for different cases:
-
-            // number_of_dense_limbs = 4 & fine_limb_len = 0 or
-            // number_of_dense_limbs = 3 & fine_limb_len > 0
-            // | A   | B   | C   | D   | E   |
-            // | --- | --- | --- | --- | --- |
-            // | a_0 | a_3 | a_1 | a_2 | in  |
-
-            // number_of_dense_limbs = 3 & fine_limb_len = 0 or
-            // number_of_dense_limbs = 2 & fine_limb_len > 0
-            // | A   | B   | C   | D   | E   |
-            // | --- | --- | --- | --- | --- |
-            // | a_0 | a_2 | a_1 | -   | in  |
-
-            // number_of_dense_limbs = 2 & fine_limb_len = 0 or
-            // number_of_dense_limbs = 1 & fine_limb_len > 0
-            // | A   | B   | C   | D   | E   |
-            // | --- | --- | --- | --- | --- |
-            // | a_0 | a_1 | -   | -   | in  |
-
-            // number_of_dense_limbs = 4 & fine_limb_len > 0
-            // | A   | B   | C   | D   | E   |
-            // | --- | --- | --- | --- | --- |
-            // | a_0 | a_3 | a_1 | a_2 | -   |
-            // | -   | a_4 | -   | in  | t   |
-
-            // Least significant Term in first row
-            let term_0 = Term::Unassigned(limbs.as_ref().map(|limbs| limbs[0]), bases[0]);
-
-            // Most significant Term in first row
-            let term_1 = if has_overflow {
-                Term::Unassigned(
-                    limbs.as_ref().map(|limbs| limbs[number_of_limbs - 2]),
-                    bases[number_of_limbs - 2],
-                )
-            } else {
-                Term::Unassigned(
-                    limbs.as_ref().map(|limbs| limbs[number_of_limbs - 1]),
-                    bases[number_of_limbs - 1],
-                )
-            };
-
-            let term_2 = if number_of_limbs > 2 {
-                Term::Unassigned(limbs.as_ref().map(|limbs| limbs[1]), bases[1])
-            } else {
-                Term::Zero
-            };
-
-            let term_3 = if number_of_limbs > 3 {
-                Term::Unassigned(limbs.as_ref().map(|limbs| limbs[2]), bases[2])
-            } else {
-                Term::Zero
-            };
-
-            if has_overflow {
-                let _ = main_gate.apply(
-                    ctx,
-                    &[term_0, term_1, term_2, term_3, Term::Zero],
-                    zero,
-                    CombinationOptionCommon::CombineToNextAdd(-one).into(),
-                )?;
-
-                assert!(number_of_limbs - 1 == 4);
-                let unassigned_input = Term::Unassigned(input, -one);
-                let (intermediate, overflow) = limbs
-                    .zip(input)
-                    .map(|(limbs, input)| {
-                        let overflow = limbs[4];
-                        // combination of previous row must go to column 'E'
-                        let intermediate = input - overflow * rrrr;
-                        (intermediate, overflow)
-                    })
-                    .unzip();
-                let intermediate = Term::Unassigned(intermediate, one);
-                let overflow = Term::Unassigned(overflow, rrrr);
-
-                // should meet with overflow bit len
-                ctx.enable(self.get_table(fine_limb_bit_len)?.selector)?;
-
-                Ok((&main_gate.apply(
-                    ctx,
-                    &[
-                        Term::Zero,
-                        overflow,
-                        Term::Zero,
-                        unassigned_input,
-                        intermediate,
-                    ],
-                    zero,
-                    CombinationOptionCommon::OneLinerAdd.into(),
-                )?[3])
-                    .clone())
-            } else {
-                let unassigned_input = Term::Unassigned(input, -one);
-                let combination_option = CombinationOptionCommon::OneLinerAdd.into();
-                Ok((&main_gate.apply(
-                    ctx,
-                    &[term_0, term_1, term_2, term_3, unassigned_input],
-                    zero,
-                    combination_option,
-                )?[4])
-                    .clone())
-            }
-        }
+        })
     }
 
-    fn load_limb_range_table(&self, layouter: &mut impl Layouter<F>) -> Result<(), Error> {
-        let table_values: Vec<F> = (0..1 << self.base_bit_len).map(|e| F::from(e)).collect();
-
-        layouter.assign_table(
-            || "",
-            |mut table| {
-                for (index, &value) in table_values.iter().enumerate() {
-                    table.assign_cell(
-                        || "limb range table",
-                        self.config.dense_limb_range_table,
-                        index,
-                        || Value::known(value),
-                    )?;
-                }
-                Ok(())
-            },
-        )?;
-        Ok(())
-    }
-
-    fn load_overflow_range_tables(&self, layouter: &mut impl Layouter<F>) -> Result<(), Error> {
-        for overflow_table in self.config.fine_tune_tables.iter() {
-            let bit_len = overflow_table.bit_len;
+    fn load_composition_tables(&self, layouter: &mut impl Layouter<F>) -> Result<(), Error> {
+        for (bit_len, config) in self.config.composition_tables.iter() {
             let table_values: Vec<F> = (0..1 << bit_len).map(|e| F::from(e)).collect();
-
             layouter.assign_table(
                 || "",
                 |mut table| {
                     for (index, &value) in table_values.iter().enumerate() {
                         table.assign_cell(
-                            || "overflow table",
-                            overflow_table.column,
+                            || "composition table",
+                            config.column,
+                            index,
+                            || Value::known(value),
+                        )?;
+                    }
+                    Ok(())
+                },
+            )?;
+        }
+
+        Ok(())
+    }
+
+    fn load_overflow_tables(&self, layouter: &mut impl Layouter<F>) -> Result<(), Error> {
+        for (bit_len, config) in self.config.overflow_tables.iter() {
+            let table_values: Vec<F> = (0..1 << bit_len).map(|e| F::from(e)).collect();
+            layouter.assign_table(
+                || "",
+                |mut table| {
+                    for (index, &value) in table_values.iter().enumerate() {
+                        table.assign_cell(
+                            || "composition table",
+                            config.column,
                             index,
                             || Value::known(value),
                         )?;
@@ -308,23 +197,18 @@ impl<F: FieldExt> RangeInstructions<F> for RangeChip<F> {
 }
 
 impl<F: FieldExt> RangeChip<F> {
-    /// Given config creates new chip that implements ranging
-    pub fn new(config: RangeConfig, base_bit_len: usize) -> Self {
-        let two = F::from(2);
-        let left_shifter_r = two.pow(&[base_bit_len as u64, 0, 0, 0]);
-        let left_shifter_2r = two.pow(&[(base_bit_len * 2) as u64, 0, 0, 0]);
-        let left_shifter_3r = two.pow(&[(base_bit_len * 3) as u64, 0, 0, 0]);
-        let left_shifter_4r = two.pow(&[(base_bit_len * 4) as u64, 0, 0, 0]);
+    fn bases(number_of_limbs: usize, bit_len: usize) -> Vec<F> {
+        assert!(number_of_limbs * bit_len > 0);
+        (0..number_of_limbs)
+            .map(|i| F::from(2).pow(&[(bit_len * i) as u64, 0, 0, 0]))
+            .collect()
+    }
 
-        RangeChip {
+    /// Given config creates new chip that implements ranging
+    pub fn new(config: RangeConfig) -> Self {
+        Self {
             config,
-            base_bit_len,
-            left_shifter: vec![
-                left_shifter_r,
-                left_shifter_2r,
-                left_shifter_3r,
-                left_shifter_4r,
-            ],
+            _marker: PhantomData,
         }
     }
 
@@ -333,16 +217,24 @@ impl<F: FieldExt> RangeChip<F> {
     pub fn configure(
         meta: &mut ConstraintSystem<F>,
         main_gate_config: &MainGateConfig,
-        fine_tune_bit_lengths: Vec<usize>,
+        composition_bit_lens: Vec<usize>,
+        overflow_bit_lens: Vec<usize>,
     ) -> RangeConfig {
-        let mut fine_tune_bit_lengths = fine_tune_bit_lengths;
-        fine_tune_bit_lengths.sort_unstable();
-        fine_tune_bit_lengths.dedup();
-        let fine_tune_bit_lengths: Vec<usize> = fine_tune_bit_lengths
+        let mut overflow_bit_lens = overflow_bit_lens;
+        overflow_bit_lens.sort_unstable();
+        overflow_bit_lens.dedup();
+        let overflow_bit_lens: Vec<usize> =
+            overflow_bit_lens.into_iter().filter(|e| *e != 0).collect();
+
+        let mut composition_bit_lens = composition_bit_lens;
+        composition_bit_lens.sort_unstable();
+        composition_bit_lens.dedup();
+        let composition_bit_lens: Vec<usize> = composition_bit_lens
             .into_iter()
             .filter(|e| *e != 0)
             .collect();
 
+        // TODO: consider for a generic MainGateConfig
         let (a, b, c, d) = (
             main_gate_config.a,
             main_gate_config.b,
@@ -350,46 +242,45 @@ impl<F: FieldExt> RangeChip<F> {
             main_gate_config.d,
         );
 
-        let s_dense_limb_range = meta.complex_selector();
-        let dense_limb_range_table = meta.lookup_table_column();
-
         macro_rules! meta_lookup {
-            ($column:expr, $selector:expr,$table:expr) => {
+            ($column:expr, $table_config:expr) => {
                 // meta.lookup(stringify!($column), |meta| {
                 meta.lookup(|meta| {
                     let exp = meta.query_advice($column, Rotation::cur());
-                    let s = meta.query_selector($selector);
-                    vec![(exp * s, $table)]
+                    let s = meta.query_selector($table_config.selector);
+                    vec![(exp * s, $table_config.column)]
                 });
             };
         }
 
-        meta_lookup!(a, s_dense_limb_range, dense_limb_range_table);
-        meta_lookup!(b, s_dense_limb_range, dense_limb_range_table);
-        meta_lookup!(c, s_dense_limb_range, dense_limb_range_table);
-        meta_lookup!(d, s_dense_limb_range, dense_limb_range_table);
+        let mut composition_tables = HashMap::<usize, TableConfig>::new();
+        let mut overflow_tables = HashMap::<usize, TableConfig>::new();
 
-        let fine_tune_tables = fine_tune_bit_lengths
-            .iter()
-            .map(|bit_len| {
-                let selector = meta.complex_selector();
-                let column = meta.lookup_table_column();
+        for bit_len in composition_bit_lens.iter() {
+            let config = TableConfig {
+                selector: meta.complex_selector(),
+                column: meta.lookup_table_column(),
+            };
+            meta_lookup!(a, config);
+            meta_lookup!(b, config);
+            meta_lookup!(c, config);
+            meta_lookup!(d, config);
+            composition_tables.insert(*bit_len, config);
+        }
+        for bit_len in overflow_bit_lens.iter() {
+            let config = TableConfig {
+                selector: meta.complex_selector(),
+                column: meta.lookup_table_column(),
+            };
 
-                meta_lookup!(b, selector, column);
-
-                TableConfig {
-                    selector,
-                    column,
-                    bit_len: *bit_len,
-                }
-            })
-            .collect();
+            meta_lookup!(a, config);
+            overflow_tables.insert(*bit_len, config);
+        }
 
         RangeConfig {
             main_gate_config: main_gate_config.clone(),
-            s_dense_limb_range,
-            dense_limb_range_table,
-            fine_tune_tables,
+            composition_tables,
+            overflow_tables,
         }
     }
 }
@@ -397,17 +288,17 @@ impl<F: FieldExt> RangeChip<F> {
 #[cfg(test)]
 mod tests {
 
+    use halo2wrong::halo2::circuit::Value;
     use halo2wrong::RegionCtx;
 
     use super::{RangeChip, RangeConfig, RangeInstructions};
     use crate::curves::pasta::Fp;
     use crate::halo2::arithmetic::FieldExt;
-    use crate::halo2::circuit::{Layouter, SimpleFloorPlanner, Value};
+    use crate::halo2::circuit::{Layouter, SimpleFloorPlanner};
     use crate::halo2::dev::MockProver;
     use crate::halo2::plonk::{Circuit, ConstraintSystem, Error};
     use crate::main_gate::MainGate;
-    use crate::range::NUMBER_OF_LOOKUP_LIMBS;
-    use crate::MainGateInstructions;
+    use crate::{MainGateInstructions, Term};
 
     #[derive(Clone, Debug)]
     struct TestCircuitConfig {
@@ -415,19 +306,19 @@ mod tests {
     }
 
     impl TestCircuitConfig {
-        fn fine_tune_bit_lengths() -> Vec<usize> {
-            (1..Self::base_bit_len()).collect()
-        }
-
-        fn base_bit_len() -> usize {
-            16
-        }
-
-        fn new<F: FieldExt>(meta: &mut ConstraintSystem<F>) -> Self {
+        fn new<F: FieldExt>(
+            meta: &mut ConstraintSystem<F>,
+            composition_bit_lens: Vec<usize>,
+            overflow_bit_lens: Vec<usize>,
+        ) -> Self {
             let main_gate_config = MainGate::<F>::configure(meta);
-            let fine_tune_bit_lengths = Self::fine_tune_bit_lengths();
-            let range_config =
-                RangeChip::<F>::configure(meta, &main_gate_config, fine_tune_bit_lengths);
+
+            let range_config = RangeChip::<F>::configure(
+                meta,
+                &main_gate_config,
+                composition_bit_lens,
+                overflow_bit_lens,
+            );
             Self { range_config }
         }
 
@@ -436,13 +327,30 @@ mod tests {
         }
 
         fn range_chip<F: FieldExt>(&self) -> RangeChip<F> {
-            RangeChip::<F>::new(self.range_config.clone(), Self::base_bit_len())
+            RangeChip::<F>::new(self.range_config.clone())
         }
+    }
+
+    #[derive(Clone, Debug)]
+    struct Input<F: FieldExt> {
+        bit_len: usize,
+        limb_bit_len: usize,
+        value: Value<F>,
     }
 
     #[derive(Default, Clone, Debug)]
     struct TestCircuit<F: FieldExt> {
-        input: Vec<(usize, Value<F>)>,
+        inputs: Vec<Input<F>>,
+    }
+
+    impl<F: FieldExt> TestCircuit<F> {
+        fn composition_bit_lens() -> Vec<usize> {
+            vec![8]
+        }
+
+        fn overflow_bit_lens() -> Vec<usize> {
+            vec![3]
+        }
     }
 
     impl<F: FieldExt> Circuit<F> for TestCircuit<F> {
@@ -454,7 +362,11 @@ mod tests {
         }
 
         fn configure(meta: &mut ConstraintSystem<F>) -> Self::Config {
-            TestCircuitConfig::new(meta)
+            TestCircuitConfig::new(
+                meta,
+                Self::composition_bit_lens(),
+                Self::overflow_bit_lens(),
+            )
         }
 
         fn synthesize(
@@ -471,12 +383,31 @@ mod tests {
                     let offset = &mut 0;
                     let ctx = &mut RegionCtx::new(&mut region, offset);
 
-                    for value in self.input.iter() {
-                        let bit_len = value.0;
-                        let value = value.1;
+                    for input in self.inputs.iter() {
+                        let value = input.value;
+                        let limb_bit_len = input.limb_bit_len;
+                        let bit_len = input.bit_len;
 
                         let a_0 = main_gate.assign_value(ctx, value)?;
-                        let a_1 = range_chip.range_value(ctx, value, bit_len)?;
+                        let (a_1, decomposed) =
+                            range_chip.decompose(ctx, value, limb_bit_len, bit_len)?;
+
+                        main_gate.assert_equal(ctx, &a_0, &a_1)?;
+
+                        use num_integer::Integer;
+                        let (number_of_limbs, overflow_bit_len) = bit_len.div_rem(&limb_bit_len);
+                        let number_of_limbs =
+                            number_of_limbs + if overflow_bit_len != 0 { 1 } else { 0 };
+
+                        let bases = RangeChip::<F>::bases(number_of_limbs, limb_bit_len);
+                        assert_eq!(bases.len(), decomposed.len());
+
+                        let terms: Vec<Term<F>> = bases
+                            .iter()
+                            .zip(decomposed.into_iter())
+                            .map(|(base, limb)| Term::Assigned(limb, *base))
+                            .collect();
+                        let a_1 = main_gate.compose(ctx, &terms[..], F::zero())?;
                         main_gate.assert_equal(ctx, &a_0, &a_1)?;
                     }
 
@@ -484,8 +415,8 @@ mod tests {
                 },
             )?;
 
-            range_chip.load_limb_range_table(&mut layouter)?;
-            range_chip.load_overflow_range_tables(&mut layouter)?;
+            range_chip.load_composition_tables(&mut layouter)?;
+            range_chip.load_overflow_tables(&mut layouter)?;
 
             Ok(())
         }
@@ -493,22 +424,22 @@ mod tests {
 
     #[test]
     fn test_range_circuit() {
-        let base_bit_len = TestCircuitConfig::base_bit_len();
-        let k: u32 = (base_bit_len + 1) as u32;
+        const LIMB_BIT_LEN: usize = 8;
+        const OVERFLOW_BIT_LEN: usize = 3;
+        let k: u32 = (LIMB_BIT_LEN + 1) as u32;
 
-        let min_bit_len = 1;
-        let max_bit_len = base_bit_len * (NUMBER_OF_LOOKUP_LIMBS + 1) - 1;
-
-        let input = (min_bit_len..=max_bit_len)
-            .map(|i| {
-                let bit_len = i as usize;
-                let value = Value::known(Fp::from_u128((1 << i) - 1));
-                (bit_len, value)
+        let inputs = (2..20)
+            .map(|number_of_limbs| {
+                let bit_len = LIMB_BIT_LEN * number_of_limbs + OVERFLOW_BIT_LEN;
+                Input {
+                    value: Value::known(Fp::from_u128((1 << bit_len) - 1)),
+                    limb_bit_len: LIMB_BIT_LEN,
+                    bit_len,
+                }
             })
             .collect();
 
-        let circuit = TestCircuit::<Fp> { input };
-
+        let circuit = TestCircuit::<Fp> { inputs };
         let public_inputs = vec![vec![]];
         let prover = match MockProver::run(k, &circuit, public_inputs) {
             Ok(prover) => prover,

--- a/maingate/src/range.rs
+++ b/maingate/src/range.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::marker::PhantomData;
 
 use super::main_gate::{MainGate, MainGateConfig};
@@ -30,8 +30,8 @@ impl TableConfig {}
 #[derive(Clone, Debug)]
 pub struct RangeConfig {
     main_gate_config: MainGateConfig,
-    composition_tables: HashMap<usize, TableConfig>,
-    overflow_tables: HashMap<usize, TableConfig>,
+    composition_tables: BTreeMap<usize, TableConfig>,
+    overflow_tables: BTreeMap<usize, TableConfig>,
 }
 
 /// ['RangeChip'] applies binary range constraints
@@ -253,8 +253,8 @@ impl<F: FieldExt> RangeChip<F> {
             };
         }
 
-        let mut composition_tables = HashMap::<usize, TableConfig>::new();
-        let mut overflow_tables = HashMap::<usize, TableConfig>::new();
+        let mut composition_tables = BTreeMap::<usize, TableConfig>::new();
+        let mut overflow_tables = BTreeMap::<usize, TableConfig>::new();
 
         for bit_len in composition_bit_lens.iter() {
             let config = TableConfig {

--- a/transcript/src/transcript.rs
+++ b/transcript/src/transcript.rs
@@ -200,10 +200,15 @@ mod tests {
             let rns = BaseFieldEccChip::<C, NUMBER_OF_LIMBS, BIT_LEN_LIMB>::rns();
 
             let main_gate_config = MainGate::<C::Scalar>::configure(meta);
-            let mut overflow_bit_lengths: Vec<usize> = vec![];
-            overflow_bit_lengths.extend(rns.overflow_lengths());
-            let range_config =
-                RangeChip::<C::Scalar>::configure(meta, &main_gate_config, overflow_bit_lengths);
+            let overflow_bit_lens = rns.overflow_lengths();
+            let composition_bit_lens = vec![BIT_LEN_LIMB / NUMBER_OF_LIMBS];
+
+            let range_config = RangeChip::<C::Scalar>::configure(
+                meta,
+                &main_gate_config,
+                composition_bit_lens,
+                overflow_bit_lens,
+            );
             TestCircuitConfig {
                 main_gate_config,
                 range_config,
@@ -211,10 +216,9 @@ mod tests {
         }
 
         fn config_range<N: FieldExt>(&self, layouter: &mut impl Layouter<N>) -> Result<(), Error> {
-            let bit_len_lookup = BIT_LEN_LIMB / NUMBER_OF_LOOKUP_LIMBS;
-            let range_chip = RangeChip::<N>::new(self.range_config.clone(), bit_len_lookup);
-            range_chip.load_limb_range_table(layouter)?;
-            range_chip.load_overflow_range_tables(layouter)?;
+            let range_chip = RangeChip::<N>::new(self.range_config.clone());
+            range_chip.load_composition_tables(layouter)?;
+            range_chip.load_overflow_tables(layouter)?;
 
             Ok(())
         }


### PR DESCRIPTION
This PR generalize range function to decompose a value more than just `NUMBER_OF_LOOKUP_LIMBS`. As well as keeps the old behaviour. So this PR should replace #30.

Also there is new function at `MainGateInstructions` named `decompose` that takes closure to enable tables while combining limbs that must be ranged in multiple rows.