### PR TITLE
Introduce constant value registry

### DIFF
--- a/ecc/src/ecc.rs
+++ b/ecc/src/ecc.rs
@@ -109,27 +109,6 @@ pub struct EccConfig {
     main_gate_config: MainGateConfig,
 }
 
-impl EccConfig {
-    /// Returns new `EccConfig` given `RangeConfig` and `MainGateConfig`
-    pub fn new(range_config: RangeConfig, main_gate_config: MainGateConfig) -> Self {
-        Self {
-            range_config,
-            main_gate_config,
-        }
-    }
-
-    /// Returns new `IntegerConfig` with matching `RangeConfig` and
-    /// `MainGateConfig`
-    pub(crate) fn integer_chip_config(&self) -> IntegerConfig {
-        IntegerConfig::new(self.range_config.clone(), self.main_gate_config.clone())
-    }
-
-    /// Returns new `MainGateConfig`
-    pub(crate) fn main_gate_config(&self) -> MainGateConfig {
-        self.main_gate_config.clone()
-    }
-}
-
 /// Finds a point we need to subtract from the end result in the efficient batch
 /// multiplication algorithm.
 ///

--- a/ecc/src/lib.rs
+++ b/ecc/src/lib.rs
@@ -20,10 +20,9 @@ pub use integer::maingate;
 use halo2::halo2curves as curves;
 
 use crate::halo2::arithmetic::{CurveAffine, FieldExt};
-use crate::integer::chip::IntegerConfig;
 use crate::integer::rns::{Integer, Rns};
 use crate::integer::AssignedInteger;
-use crate::maingate::{big_to_fe, AssignedCondition, MainGateConfig, RangeConfig};
+use crate::maingate::{big_to_fe, AssignedCondition};
 use group::Curve;
 use num_bigint::BigUint as big_uint;
 use num_traits::One;
@@ -119,29 +118,6 @@ impl<W: FieldExt, N: FieldExt, const NUMBER_OF_LIMBS: usize, const BIT_LEN_LIMB:
     /// Returns $y$ coordinate
     pub fn y(&self) -> &AssignedInteger<W, N, NUMBER_OF_LIMBS, BIT_LEN_LIMB> {
         &self.y
-    }
-}
-
-/// Config for Ecc Chip
-#[derive(Clone, Debug)]
-pub struct EccConfig {
-    range_config: RangeConfig,
-    main_gate_config: MainGateConfig,
-}
-
-impl EccConfig {
-    /// Returns new `EccConfig` given `RangeConfig` and `MainGateConfig`
-    pub fn new(range_config: RangeConfig, main_gate_config: MainGateConfig) -> Self {
-        Self {
-            range_config,
-            main_gate_config,
-        }
-    }
-
-    /// Returns new `IntegerConfig` with matching `RangeConfig` and
-    /// `MainGateConfig`
-    pub(crate) fn integer_chip_config(&self) -> IntegerConfig {
-        IntegerConfig::new(self.range_config.clone(), self.main_gate_config.clone())
     }
 }
 

--- a/ecdsa/src/lib.rs
+++ b/ecdsa/src/lib.rs
@@ -2,7 +2,6 @@ pub mod ecdsa;
 
 pub(crate) use ecc::halo2;
 pub(crate) use ecc::integer;
-pub(crate) use ecc::maingate;
 
 #[cfg(test)]
 use halo2::halo2curves as curves;

--- a/integer/src/instructions.rs
+++ b/integer/src/instructions.rs
@@ -3,6 +3,7 @@ use crate::maingate::{halo2, AssignedCondition, RegionCtx};
 use crate::rns::Integer;
 use halo2::arithmetic::FieldExt;
 use halo2::plonk::Error;
+use maingate::halo2::circuit::Layouter;
 
 /// Signals the range mode that should be applied while assigning a new
 /// [`Integer`]
@@ -35,11 +36,17 @@ pub trait IntegerInstructions<
         range: Range,
     ) -> Result<AssignedInteger<W, N, NUMBER_OF_LIMBS, BIT_LEN_LIMB>, Error>;
 
+    /// Assigns an [`Integer`] constants
+    fn register_constants(
+        &mut self,
+        layouter: &mut impl Layouter<N>,
+        integer: Vec<W>,
+    ) -> Result<(), Error>;
+
     /// Assigns an [`Integer`] constant to a cell in the circuit returning an
     /// [`AssignedInteger`].
-    fn assign_constant(
+    fn get_constant(
         &self,
-        ctx: &mut RegionCtx<'_, N>,
         integer: W,
     ) -> Result<AssignedInteger<W, N, NUMBER_OF_LIMBS, BIT_LEN_LIMB>, Error>;
 

--- a/integer/src/lib.rs
+++ b/integer/src/lib.rs
@@ -12,7 +12,7 @@ use num_bigint::BigUint as big_uint;
 use rns::Rns;
 use std::rc::Rc;
 
-pub use chip::{IntegerChip, IntegerConfig};
+pub use chip::IntegerChip;
 pub use instructions::{IntegerInstructions, Range};
 pub use maingate;
 pub use maingate::halo2;


### PR DESCRIPTION
This PR adds registry that assigns constant values to an advice column in order to propagate constants via permutations. It will be useful for decomposition in vertical product gate which is without fixed columns.