### PR TITLE
Update halo2_proofs to v2023_01_17

### DIFF
--- a/ecc/src/base_field_ecc.rs
+++ b/ecc/src/base_field_ecc.rs
@@ -508,7 +508,7 @@ mod tests {
         fn run<C: CurveAffine>() {
             let circuit = TestEccAddition::<C>::default();
             let instance = vec![vec![]];
-            assert_eq!(mock_prover_verify(&circuit, instance), Ok(()));
+            mock_prover_verify(&circuit, instance);
         }
         run::<Bn256>();
         run::<Pallas>();
@@ -599,7 +599,7 @@ mod tests {
                 b: Value::known(b),
             };
             let instance = vec![public_data];
-            assert_eq!(mock_prover_verify(&circuit, instance), Ok(()));
+            mock_prover_verify(&circuit, instance);
         }
 
         run::<Bn256>();
@@ -686,7 +686,7 @@ mod tests {
                     window_size,
                 };
                 let instance = vec![vec![]];
-                assert_eq!(mock_prover_verify(&circuit, instance), Ok(()));
+                mock_prover_verify(&circuit, instance);
             }
         }
         run::<Bn256>();
@@ -788,7 +788,7 @@ mod tests {
                                 number_of_pairs,
                             };
                             let instance = vec![vec![]];
-                            assert_eq!(mock_prover_verify(&circuit, instance), Ok(()));
+                            mock_prover_verify(&circuit, instance);
                         }
                     }
                 }

--- a/ecc/src/general_ecc.rs
+++ b/ecc/src/general_ecc.rs
@@ -591,7 +591,7 @@ mod tests {
         >() {
             let circuit = TestEccAddition::<C, N, NUMBER_OF_LIMBS, BIT_LEN_LIMB>::default();
             let instance = vec![vec![]];
-            assert_eq!(mock_prover_verify(&circuit, instance), Ok(()));
+            mock_prover_verify(&circuit, instance);
         }
 
         run::<Pallas, BnScalar, NUMBER_OF_LIMBS, BIT_LEN_LIMB>();
@@ -708,7 +708,7 @@ mod tests {
                 ..Default::default()
             };
             let instance = vec![public_data];
-            assert_eq!(mock_prover_verify(&circuit, instance), Ok(()));
+            mock_prover_verify(&circuit, instance);
         }
 
         run::<Pallas, BnScalar, NUMBER_OF_LIMBS, BIT_LEN_LIMB>();
@@ -827,7 +827,7 @@ mod tests {
                     ..Default::default()
                 };
                 let instance = vec![vec![]];
-                assert_eq!(mock_prover_verify(&circuit, instance), Ok(()));
+                mock_prover_verify(&circuit, instance);
             }
         }
 
@@ -957,7 +957,7 @@ mod tests {
                                 ..Default::default()
                             };
                             let instance = vec![vec![]];
-                            assert_eq!(mock_prover_verify(&circuit, instance), Ok(()));
+                            mock_prover_verify(&circuit, instance);
                         }
                     }
                 }

--- a/ecdsa/src/ecdsa.rs
+++ b/ecdsa/src/ecdsa.rs
@@ -343,7 +343,7 @@ mod tests {
                 ..Default::default()
             };
             let instance = vec![vec![]];
-            assert_eq!(mock_prover_verify(&circuit, instance), Ok(()));
+            mock_prover_verify(&circuit, instance);
         }
 
         use crate::curves::bn256::Fr as BnScalar;

--- a/halo2wrong/Cargo.toml
+++ b/halo2wrong/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 num-bigint = { version = "0.4", features = ["rand"] }
 num-integer = "0.1"
 num-traits = "0.2"
-halo2 = { package = "halo2_proofs", git = "https://github.com/privacy-scaling-explorations/halo2", tag = "v2022_10_22" }
+halo2 = { package = "halo2_proofs", git = "https://github.com/privacy-scaling-explorations/halo2", tag = "v2023_01_17" }
 group = "0.12"
 
 [dev-dependencies]

--- a/integer/src/chip.rs
+++ b/integer/src/chip.rs
@@ -1518,7 +1518,7 @@ mod tests {
 
                 let circuit = $circuit::<$wrong_field, $native_field, $bit_len_limb> { rns: Rc::new(rns) };
             let instance = vec![vec![]];
-            assert_eq!(mock_prover_verify(&circuit, instance), Ok(()));
+            mock_prover_verify(&circuit, instance);
             )*
         };
     }

--- a/transcript/src/transcript.rs
+++ b/transcript/src/transcript.rs
@@ -322,7 +322,7 @@ mod tests {
                             expected: Value::known(expected),
                         };
                         let instance = vec![vec![]];
-                        assert_eq!(mock_prover_verify(&circuit, instance), Ok(()));
+                        mock_prover_verify(&circuit, instance);
                     }
                 }
             }


### PR DESCRIPTION
Ports the repo to the latest halo2 release and also includes the 
`annotate_column` trait-fn required by `DimensionMeasurement`.

Since the new release of halo2_2023_10_17, `VerifyFailure` now has a
reference to the prover itself.

That means that we can't return the failures if we are out of the prover
scope.
To adapt to the situation, the fn `mock_prover_verify` has been changed
so that does the assertion inside.

Resolves: https://github.com/privacy-scaling-explorations/halo2wrong/issues/60