### PR TITLE
Fix an error - 'attempt to shift left with overflow' in test_range_circuit

### DIFF
--- a/maingate/src/range.rs
+++ b/maingate/src/range.rs
@@ -384,9 +384,9 @@ impl<F: PrimeField> RangeChip<F> {
 #[cfg(test)]
 mod tests {
 
+    use halo2wrong::halo2::arithmetic::Field;
     use halo2wrong::halo2::circuit::Value;
     use halo2wrong::RegionCtx;
-    use num_bigint::BigUint;
 
     use super::{RangeChip, RangeConfig, RangeInstructions};
     use crate::curves::{ff::PrimeField, pasta::Fp};
@@ -511,18 +511,6 @@ mod tests {
         }
     }
 
-    fn split_biguint(v: BigUint) -> [u64; 4] {
-        let digits = v.to_u64_digits();
-        let mut result = [0; 4];
-        for (i, &digit) in digits.iter().enumerate() {
-            if i >= 4 {
-                break;
-            }
-            result[i] = digit;
-        }
-        result
-    }
-
     #[test]
     fn test_range_circuit() {
         const LIMB_BIT_LEN: usize = 8;
@@ -532,9 +520,9 @@ mod tests {
         let inputs = (2..20)
             .map(|number_of_limbs| {
                 let bit_len = LIMB_BIT_LEN * number_of_limbs + OVERFLOW_BIT_LEN;
-                let value = BigUint::from(1u32) << 16 - 1;
+                let value = Fp::from(2).pow(&[bit_len as u64, 0, 0, 0]) - Fp::one();
                 Input {
-                    value: Value::known(Fp::from_raw(split_biguint(value))),
+                    value: Value::known(value),
                     limb_bit_len: LIMB_BIT_LEN,
                     bit_len,
                 }

--- a/maingate/src/range.rs
+++ b/maingate/src/range.rs
@@ -386,6 +386,7 @@ mod tests {
 
     use halo2wrong::halo2::circuit::Value;
     use halo2wrong::RegionCtx;
+    use num_bigint::BigUint;
 
     use super::{RangeChip, RangeConfig, RangeInstructions};
     use crate::curves::{ff::PrimeField, pasta::Fp};
@@ -510,6 +511,18 @@ mod tests {
         }
     }
 
+    fn split_biguint(v: BigUint) -> [u64; 4] {
+        let digits = v.to_u64_digits();
+        let mut result = [0; 4];
+        for (i, &digit) in digits.iter().enumerate() {
+            if i >= 4 {
+                break;
+            }
+            result[i] = digit;
+        }
+        result
+    }
+
     #[test]
     fn test_range_circuit() {
         const LIMB_BIT_LEN: usize = 8;
@@ -519,8 +532,9 @@ mod tests {
         let inputs = (2..20)
             .map(|number_of_limbs| {
                 let bit_len = LIMB_BIT_LEN * number_of_limbs + OVERFLOW_BIT_LEN;
+                let value = BigUint::from(1u32) << 16 - 1;
                 Input {
-                    value: Value::known(Fp::from_u128((1 << bit_len) - 1)),
+                    value: Value::known(Fp::from_raw(split_biguint(value))),
                     limb_bit_len: LIMB_BIT_LEN,
                     bit_len,
                 }


### PR DESCRIPTION
### Description

Fix an error when we run ```range::tests::test_range_circuit```. The full error message is 
```
running 1 test
thread 'range::tests::test_range_circuit' panicked at 'attempt to shift left with overflow', maingate/src/range.rs:523:55
stack backtrace:
   0: rust_begin_unwind
             at /rustc/4b91a6ea7258a947e59c6522cd5898e7c0a6a88f/library/std/src/panicking.rs:584:5
   1: core::panicking::panic_fmt
             at /rustc/4b91a6ea7258a947e59c6522cd5898e7c0a6a88f/library/core/src/panicking.rs:142:14
   2: core::panicking::panic
             at /rustc/4b91a6ea7258a947e59c6522cd5898e7c0a6a88f/library/core/src/panicking.rs:48:5
   3: maingate::range::tests::test_range_circuit::{{closure}}
             at ./src/range.rs:523:55
   4: core::iter::adapters::map::map_fold::{{closure}}
             at /rustc/4b91a6ea7258a947e59c6522cd5898e7c0a6a88f/library/core/src/iter/adapters/map.rs:84:28
   5: core::iter::traits::iterator::Iterator::fold
             at /rustc/4b91a6ea7258a947e59c6522cd5898e7c0a6a88f/library/core/src/iter/traits/iterator.rs:2370:21
   6: <core::iter::adapters::map::Map<I,F> as core::iter::traits::iterator::Iterator>::fold
             at /rustc/4b91a6ea7258a947e59c6522cd5898e7c0a6a88f/library/core/src/iter/adapters/map.rs:124:9
   7: core::iter::traits::iterator::Iterator::for_each
             at /rustc/4b91a6ea7258a947e59c6522cd5898e7c0a6a88f/library/core/src/iter/traits/iterator.rs:787:9
   8: <alloc::vec::Vec<T,A> as alloc::vec::spec_extend::SpecExtend<T,I>>::spec_extend
             at /rustc/4b91a6ea7258a947e59c6522cd5898e7c0a6a88f/library/alloc/src/vec/spec_extend.rs:40:17
   9: <alloc::vec::Vec<T> as alloc::vec::spec_from_iter_nested::SpecFromIterNested<T,I>>::from_iter
             at /rustc/4b91a6ea7258a947e59c6522cd5898e7c0a6a88f/library/alloc/src/vec/spec_from_iter_nested.rs:62:9
  10: <alloc::vec::Vec<T> as alloc::vec::spec_from_iter::SpecFromIter<T,I>>::from_iter
             at /rustc/4b91a6ea7258a947e59c6522cd5898e7c0a6a88f/library/alloc/src/vec/spec_from_iter.rs:33:9
  11: <alloc::vec::Vec<T> as core::iter::traits::collect::FromIterator<T>>::from_iter
             at /rustc/4b91a6ea7258a947e59c6522cd5898e7c0a6a88f/library/alloc/src/vec/mod.rs:2645:9
  12: core::iter::traits::iterator::Iterator::collect
             at /rustc/4b91a6ea7258a947e59c6522cd5898e7c0a6a88f/library/core/src/iter/traits/iterator.rs:1792:9
  13: maingate::range::tests::test_range_circuit
             at ./src/range.rs:519:22
  14: maingate::range::tests::test_range_circuit::{{closure}}
             at ./src/range.rs:514:5
  15: core::ops::function::FnOnce::call_once
             at /rustc/4b91a6ea7258a947e59c6522cd5898e7c0a6a88f/library/core/src/ops/function.rs:248:5
  16: core::ops::function::FnOnce::call_once
             at /rustc/4b91a6ea7258a947e59c6522cd5898e7c0a6a88f/library/core/src/ops/function.rs:248:5
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
test range::tests::test_range_circuit ... FAILED

failures:

failures:
    range::tests::test_range_circuit

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 9 filtered out; finished in 0.07s
```


### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Contents

The maximum integer type in Rust is u128, which represents an unsigned 128-bit integer. When the bit_len is large than 16, ```1 << 16``` returns an error since the left shift operation results in an overflow, as shifting by 16 positions exceeds the range of u128. In such cases, we can use a larger integer type like u512 to accommodate the desired shift. u512 represents a 512-bit unsigned integer, which is wider than u128. 

### Rationale

I choose ```num_bigint::BigUint``` here

### How Has This Been Tested?
Run the following command 
```
cargo test --package maingate --lib --all-features -- range::tests::test_range_circuit --exact --nocapture 
```
