### PR TITLE
fix: modify `EcdsaConfig` struct to make range config as public

### DIFF
--- a/ecdsa/src/ecdsa.rs
+++ b/ecdsa/src/ecdsa.rs
@@ -14,7 +14,7 @@ use maingate::{MainGateConfig, RangeConfig};
 #[derive(Clone, Debug)]
 pub struct EcdsaConfig {
     main_gate_config: MainGateConfig,
-    range_config: RangeConfig,
+    pub range_config: RangeConfig,
 }
 
 impl EcdsaConfig {


### PR DESCRIPTION
Made `range_config` field on `EcdsaConfig` struct as public in order to access it in witness generation => #75 

An alternative approach might be creating a getter method on the struct