### PR TITLE
fix: typos in documentation files

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 `halo2wrong` consist of a simple PLONK gate and non native arithmetic based applications. Any crate here may use either [zcash/halo2](https://github.com/zcash/halo2) or [privacy-scaling-explorations/halo2](https://github.com/privacy-scaling-explorations/halo2) which is a fork of original halo2 library that replaces commitment scheme from IPA to KZG.
 
-* `maingate` includes a 4 width and a 5 width standart-like PLONK gate.
-* `integer` implements non native field arithemetic often called big integer arithmetic.
+* `maingate` includes a 4 width and a 5 width standard-like PLONK gate.
+* `integer` implements non native field arithmetic often called big integer arithmetic.
 * `ecc` constraints elliptic curve operations ie. addition, multiplication point assignments.
-* `ecdsa` is the first application that uses `halo2wrong` stack and constaints ECDSA signature verification.
+* `ecdsa` is the first application that uses `halo2wrong` stack and constraints ECDSA signature verification.
 
 ## License
 

--- a/maingate/README.md
+++ b/maingate/README.md
@@ -1,7 +1,7 @@
 
 # `maingate`
 
-`maingate` implements various standart like plonk arithmetic gates for halo2 backend. `MainGateInstructions` trait has many primitives such as arithemtic operations, assignments, assertions and branching instructions.
+`maingate` implements various standard like plonk arithmetic gates for halo2 backend. `MainGateInstructions` trait has many primitives such as arithmetic operations, assignments, assertions and branching instructions.
 
 ## Main Gate
 
@@ -12,6 +12,6 @@ Currently one four width gate and one five width gate are available with followi
 
 ## Range Gate
 
-Range gate utilizes witness columns in the main gate. So it's a custom gate only with some selector column contributions. Range gates basically combines upto 5 limbs of a value where limbs are tested against tables. For example for 55 bit value range gate combines three 17 bit limbs and one 4 bit limb. In that case we have two tables one commits to values in `[0, 2^17)` and the other to `[0, 2^4)`.
+Range gate utilizes witness columns in the main gate. So it's a custom gate only with some selector column contributions. Range gates basically combines up to 5 limbs of a value where limbs are tested against tables. For example for 55 bit value range gate combines three 17 bit limbs and one 4 bit limb. In that case we have two tables one commits to values in `[0, 2^17)` and the other to `[0, 2^4)`.
 
 Upto 4 limbs range proof takes only single row with 5 limbs it will be two rows.


### PR DESCRIPTION
This pull request contains changes to improve clarity, correctness and structure.

**Description correction:**
Corrected `standart` to `standard` x3.
Corrected `arithemetic` to `arithmetic` x3.
Corrected `constaints` to `constraints`.
Corrected `upto` to `up to`.
Please review the changes and let me know if any additional changes are needed.

